### PR TITLE
IncSearch and Search columns are the same

### DIFF
--- a/colors/candid.vim
+++ b/colors/candid.vim
@@ -87,7 +87,7 @@ call <sid>hi('WarningMsg', s:mustard, s:none, 'italic', {})
 call <sid>hi('Noise', s:mummys_tomb, s:none, 'none', {})
 call <sid>hi('NonText', s:mustard, s:none, 'none', {})
 call <sid>hi('Folded', s:mummys_tomb, s:none, 'none', {})
-call <sid>hi('IncSearch', s:mustard, s:raisin_black, 'none', {})
+call <sid>hi('IncSearch', s:mustard, s:raisin_black, 'reverse', {})
 call <sid>hi('Search', s:mustard, s:raisin_black, 'reverse', {})
 
 call <sid>hi('Pmenu', s:raisin_black, s:mummys_tomb, 'none', {})


### PR DESCRIPTION
Thank you for creating this theme! I'm loving it!

I've ran into one oddity. When using the incsearch option I've noticed that all the matches have a visible yellow background, apart from the first match which doesn't. As you type more characters into the search and narrow down the options the first match might move. When I look at one of the matches while I type and it becomes the first match, the disappearance of the yellow background is so immediate that it feels like I typed a wrong character and it's no longer a match.

Not sure this is an intentional design or not. If not, I believe this change is the fix. Having tried it out locally, it makes all the search matches look the same.