### PR TITLE
Improve visibility of cursor line

### DIFF
--- a/colors/candid.vim
+++ b/colors/candid.vim
@@ -65,7 +65,7 @@ call <sid>hi('Normal', s:foreground, s:background, 'none', {})
 call <sid>hi('Cursor', s:none, s:none, 'inverse', {})
 hi link lCursor Cursor
 hi link CursorIM Cursor
-call <sid>hi('CursorLine', s:raisin_black, s:mummys_tomb, 'none', {})
+call <sid>hi('CursorLine', s:none, s:pale_black, 'none', {})
 call <sid>hi('EndOfBuffer', s:mustard, s:none, 'none', {})
 call <sid>hi('Conceal', s:sea_serpent, s:none, 'none', {})
 call <sid>hi('CursorColumn', s:none, s:sea_serpent, 'none', {})


### PR DESCRIPTION
First of all, thank you for the beautiful theme. I love it.

I always display the cursor line and I find that without syntax highlighting and with the decreased contrast it is hard to see what is going on as I type. 

This PR enables syntax highlighting in the cursor line and uses a background color that creates a higher contrast.

## Before
<img width="566" alt="Screenshot 2020-02-08 at 17 59 45" src="https://user-images.githubusercontent.com/11493705/74089825-263bde00-4a9d-11ea-8898-ac5f755760c1.png">

## After
<img width="566" alt="Screenshot 2020-02-08 at 18 00 36" src="https://user-images.githubusercontent.com/11493705/74089822-23d98400-4a9d-11ea-92ff-6f2499dfe441.png">
